### PR TITLE
fix xarray time warning

### DIFF
--- a/velosearaptor/io.py
+++ b/velosearaptor/io.py
@@ -197,7 +197,7 @@ def yday0_to_datetime64(baseyear, yday):
     base = datetime.datetime(baseyear, 1, 1, 0, 0, 0)
     time = [base + datetime.timedelta(days=ti) for ti in yday]
     # convert to numpy datetime64
-    time64 = np.array([np.datetime64(ti, "ms") for ti in time])
+    time64 = np.array([np.datetime64(ti, "ns") for ti in time])
     return time64
 
 

--- a/velosearaptor/madcp.py
+++ b/velosearaptor/madcp.py
@@ -1495,7 +1495,7 @@ class ProcessADCP:
         # generate time vector
         base = datetime.datetime(dat.yearbase, 1, 1, 0, 0, 0)
         time = [base + datetime.timedelta(days=ti) for ti in dat.dday]
-        adcptime = [np.datetime64(ti) for ti in time]
+        adcptime = [np.datetime64(ti, "ns") for ti in time]
         # generate Dataset
         out = xr.Dataset(
             {"pg": (["depth", "time"], dat.pg.T)},


### PR DESCRIPTION
`xarray` complains about time vectors that are not nanosecond precision. Fix this in two places.