### PR TITLE
Time limit as string

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,6 +11,7 @@
 - Allow for external input of pressure time series in `velosearaptor.madcp.ProcessADCP` ([PR12]( https://github.com/modscripps/velosearaptor/pull/12)).
 - Improve default depth grid to also work well with mooring knockdowns ([PR44]( https://github.com/modscripps/velosearaptor/pull/44)).
 - Optionally read processing parameters from .yml-file ([PR26]( https://github.com/modscripps/velosearaptor/pull/26)).
+- Allow for string format when supplying start and end time in .yml parameter file ([PR63]( https://github.com/modscripps/velosearaptor/pull/63)).
 - Add CF-compliant meta data to output dataset ([PR26]( https://github.com/modscripps/velosearaptor/pull/26)).
 
 #### Breaking Changes

--- a/notebooks/parameters.yml
+++ b/notebooks/parameters.yml
@@ -59,6 +59,8 @@ mooring:
     #    dt_hours:
     #    t0:
     #    t1:
+    #    # note: t0 and t1 can be given in dday or
+    #    # as string that can be read by np.datetime64
     #    burst_average:
     #  meta_data:
 

--- a/velosearaptor/madcp.py
+++ b/velosearaptor/madcp.py
@@ -203,7 +203,8 @@ class ProcessADCP:
       convenience method `generate_binmask`.
     - `pg_limit` : float or int or None.
             Percent good limit applied prior to interpolating to the universal
-            depth grid in `burst_average_ensembles`.
+            depth grid in `burst_average_ensembles`. Not applied in
+            `average_ensembles` as the user can filter based on pg later.
 
     """
 
@@ -584,6 +585,14 @@ class ProcessADCP:
         default_tgridparams = dict(dt_hours=0.5, t0=t0, t1=t1, burst_average=False)
         self.tgridparams = Bunch(default_tgridparams)
         if tgridparams is not None:
+            # convert time to dday if provided as str
+            for time in ["t0", "t1"]:
+                if time in tgridparams:
+                    if isinstance(tgridparams[time], str):
+                        t64 = np.datetime64(tgridparams[time])
+                        year, dday = io.datetime64_to_yday0(t64)
+                        tgridparams[time] = dday
+            # update parameters in processing object
             self.tgridparams.update_values(tgridparams, strict=True)
         else:
             logger.warning(

--- a/velosearaptor/tests/test_io.py
+++ b/velosearaptor/tests/test_io.py
@@ -1,0 +1,21 @@
+"""Test tools."""
+import numpy as np
+import pytest
+
+import velosearaptor as vr
+
+
+class TestTimeConversion:
+
+    def test_single_value(self):
+        test_dt64 = np.datetime64("2023-06-01 12:30:22")
+        year, test_yd0 = vr.io.datetime64_to_yday0(test_dt64)
+        dt64_return = vr.io.yday0_to_datetime64(year, test_yd0)
+        assert dt64_return == test_dt64
+
+    def test_array(self):
+        test_dt64 = np.arange('2023-06-01 12:00:00', '2023-06-01 12:30:00', dtype='datetime64[s]')
+        year, test_yd0 = vr.io.datetime64_to_yday0(test_dt64)
+        dt64_return = vr.io.yday0_to_datetime64(year, test_yd0)
+        np.testing.assert_equal(dt64_return, test_dt64)
+


### PR DESCRIPTION
Allow for `t0` and `t1` to be passed as strings in yaml parameter file.