### PR TITLE
Fix non-monotonic ADCP time vectors

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -26,6 +26,7 @@
 - Read paths provided via pathlib.PosixPath objects ([PR55]( https://github.com/modscripps/velosearaptor/pull/55)). By [Gunnar Voet](https://github.com/gunnarvoet/).
 - Fix xarray warning in `groupby` ([PR55]( https://github.com/modscripps/velosearaptor/pull/64)). By [Gunnar Voet](https://github.com/gunnarvoet/).
 - Replace scipy.stats.mode with np.unique for dominant period calculation ([#66] ( https://github.com/modscripps/velosearaptor/pull/66)).
+- Fix non-monotonic ADCP time vectors by interpolating isolated bad pings, truncating segment overlaps, or raising on ambiguous cases ([PR70](https://github.com/modscripps/velosearaptor/pull/70)).
 
 #### Documentation
 - Consolidate readme and history files.

--- a/velosearaptor/madcp.py
+++ b/velosearaptor/madcp.py
@@ -257,6 +257,7 @@ class ProcessADCP:
         self._set_up_logger()
 
         self.parse_driftparams(driftparams)
+        self._ensure_monotonic_dday()
         self._parse_sysconfig()
         self.parse_dgridparams(dgridparams)
         self.parse_tgridparams(tgridparams)
@@ -664,6 +665,91 @@ class ProcessADCP:
         """
 
         return self.t0 + self.time_drift_rate * (dday_orig - self.t0)
+
+    def _ensure_monotonic_dday(self):
+        """Detect and fix non-monotonic time vectors.
+
+        Three cases:
+
+        - Isolated non-monotonic pings (short runs of <= ``_max_interp_pings``
+          consecutive backward steps): replaced by linear interpolation from
+          the nearest valid neighbors.  Array length is preserved so
+          ``self.m`` index alignment is maintained.
+        - Segment overlap (backward jump where all remaining pings stay below
+          the pre-jump maximum): the array is truncated at the jump.  Only
+          tail removal is performed so index alignment is maintained.
+        - Ambiguous (longer non-monotonic stretch that eventually recovers):
+          raises ``ValueError`` so the caller can inspect and decide.
+
+        Called automatically from ``__init__`` after ``parse_driftparams``
+        sets ``self.dday``.
+        """
+        _max_interp_pings = 3
+
+        diffs = np.diff(self.dday)
+        bad = np.where(diffs <= 0)[0]
+        if len(bad) == 0:
+            return
+
+        # Classify: does the data after the first jump overlap the prior segment?
+        first_jump = bad[0]
+        pre_jump_max = self.dday[first_jump]
+        after = self.dday[first_jump + 1 :]
+        n_overlap = 0
+        for val in after:
+            if val < pre_jump_max:
+                n_overlap += 1
+            else:
+                break
+
+        if n_overlap <= _max_interp_pings:
+            # --- Isolated bad pings: interpolate dday values ---
+            fix_idx = bad + 1
+            logger.warning(
+                "Non-monotonic time: interpolating %d isolated "
+                "non-monotonic ping(s) at indices %s.",
+                len(fix_idx),
+                fix_idx,
+            )
+            for idx in fix_idx:
+                if idx == 0:
+                    self.dday[idx] = self.dday[idx + 1] - np.median(
+                        diffs[diffs > 0]
+                    )
+                elif idx >= len(self.dday) - 1:
+                    self.dday[idx] = self.dday[idx - 1] + np.median(
+                        diffs[diffs > 0]
+                    )
+                else:
+                    self.dday[idx] = (
+                        self.dday[idx - 1] + self.dday[idx + 1]
+                    ) / 2
+
+        elif n_overlap >= len(after):
+            # --- Segment overlap: all remaining pings below pre-jump max ---
+            n_total = len(self.dday)
+            keep = slice(None, first_jump + 1)
+            logger.warning(
+                "Non-monotonic time: backward jump at ping %d with %d "
+                "overlapping pings. Truncating to first %d pings.",
+                first_jump,
+                n_total - first_jump - 1,
+                first_jump + 1,
+            )
+            self.dday = self.dday[keep]
+            self.tsdat.dday = self.tsdat.dday[keep]
+            self.tsdat.pressure = self.tsdat.pressure[keep]
+            self.tsdat.temperature = self.tsdat.temperature[keep]
+            self.tsdat.ens_num = self.tsdat.ens_num[keep]
+
+        else:
+            # --- Ambiguous: long non-monotonic stretch that recovers ---
+            raise ValueError(
+                f"Non-monotonic time: backward jump at ping {first_jump} "
+                f"with {n_overlap} non-monotonic pings that eventually "
+                f"recover. Cannot auto-fix — inspect the time vector "
+                f"and handle manually."
+            )
 
     def _parse_sysconfig(self):
         # We have to get the up/down reading from sysconfig for a time when the

--- a/velosearaptor/tests/test_monotonic.py
+++ b/velosearaptor/tests/test_monotonic.py
@@ -1,0 +1,66 @@
+"""Tests for ProcessADCP._ensure_monotonic_dday."""
+
+import numpy as np
+import pytest
+from pycurrents.system import Bunch
+
+from velosearaptor.madcp import ProcessADCP
+
+
+def _make_stub(dday):
+    """Create a minimal ProcessADCP stub with dday and tsdat set."""
+    obj = object.__new__(ProcessADCP)
+    obj.dday = np.array(dday, dtype=float)
+    obj.tsdat = Bunch(
+        dday=np.array(dday, dtype=float),
+        pressure=np.ones(len(dday)),
+        temperature=np.ones(len(dday)) * 15.0,
+        ens_num=np.arange(len(dday)),
+    )
+    return obj
+
+
+def test_already_monotonic():
+    obj = _make_stub([0.0, 0.1, 0.2, 0.3, 0.4])
+    obj._ensure_monotonic_dday()
+    np.testing.assert_array_equal(obj.dday, [0.0, 0.1, 0.2, 0.3, 0.4])
+
+
+def test_single_isolated_bad_ping():
+    # One ping jumps backward — should be interpolated
+    dday = [0.0, 0.1, 0.05, 0.3, 0.4]
+    obj = _make_stub(dday)
+    obj._ensure_monotonic_dday()
+    # Index 2 should be interpolated between 0.1 and 0.3
+    assert obj.dday[2] == pytest.approx(0.2)
+    assert len(obj.dday) == 5  # length preserved
+
+
+def test_segment_overlap_truncation():
+    # Time resets and never recovers — should truncate
+    dday = [0.0, 0.1, 0.2, 0.3, 0.05, 0.06, 0.07, 0.08]
+    obj = _make_stub(dday)
+    obj._ensure_monotonic_dday()
+    np.testing.assert_array_equal(obj.dday, [0.0, 0.1, 0.2, 0.3])
+    assert len(obj.tsdat.dday) == 4
+    assert len(obj.tsdat.pressure) == 4
+    assert len(obj.tsdat.temperature) == 4
+    assert len(obj.tsdat.ens_num) == 4
+
+
+def test_ambiguous_raises():
+    # Backward jump that eventually recovers past the pre-jump max
+    dday = [0.0, 0.1, 0.2, 0.3, 0.05, 0.06, 0.07, 0.08, 0.09, 0.35, 0.4]
+    obj = _make_stub(dday)
+    with pytest.raises(ValueError, match="Cannot auto-fix"):
+        obj._ensure_monotonic_dday()
+
+
+def test_bad_ping_at_end():
+    # Last ping is non-monotonic — should be interpolated using median dt
+    dday = [0.0, 0.1, 0.2, 0.3, 0.1]
+    obj = _make_stub(dday)
+    obj._ensure_monotonic_dday()
+    # Should use median of positive diffs (0.1) added to previous value (0.3)
+    assert obj.dday[4] == pytest.approx(0.4)
+    assert len(obj.dday) == 5


### PR DESCRIPTION
## Summary

- Add `_ensure_monotonic_dday()` to `ProcessADCP`, called from `__init__` after `parse_driftparams` and before `_parse_sysconfig`
- Handles three cases: interpolates isolated bad pings (<=3 consecutive), truncates segment overlaps (backward jump with no recovery), raises `ValueError` for ambiguous cases
- Prevents silent corruption in `rangeslice`/`searchsorted` downstream when time vectors are non-monotonic

## Test plan

- [x] 5 new unit tests in `test_monotonic.py` (monotonic, isolated ping, segment overlap, ambiguous, edge case)
- [x] All 12 existing tests pass
- [x] Verified against MOTIVE WH300 SN22525 and Sentinel V50 SN24449