### PR TITLE
Document the z coordinate of the raw output

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -33,6 +33,7 @@
 #### Documentation
 - Consolidate readme and history files.
 - Add button with link to source code on GitHub ([PR43]( https://github.com/modscripps/velosearaptor/pull/43)).
+- Describe the `z` coordinate of the raw output in its attributes ([#52](https://github.com/modscripps/velosearaptor/issues/52)). `z` is the distance from the transducer to each bin, not water depth, and keeps its name for that reason; the processed dataset provides actual depth as `depth`.
 
 #### Internal Changes
 - Remove `gvpy` dependency ([PR27]( https://github.com/modscripps/velosearaptor/pull/27)).

--- a/src/velosearaptor/io.py
+++ b/src/velosearaptor/io.py
@@ -108,6 +108,10 @@ def read_raw_rdi(file, auxillary_only=False):
     out.attrs["pingtype"] = radcp.pingtype
     out.attrs["cellsize"] = radcp.CellSize
 
+    # Document the vertical coordinate. `z` is the distance from the
+    # transducer, not water depth - see cf_conventions().
+    out.z.attrs = cf_conventions()["z"]
+
     return out
 
 
@@ -385,6 +389,21 @@ def cf_conventions():
             "units": "m",
             "positive": "down",
             "coverage_content_type": "coordinate",
+        },
+        # No standard_name here: CF has no standard name for the range from an
+        # ADCP transducer to a bin. Note this is a distance, not a depth, and
+        # therefore carries no `positive` attribute either.
+        "z": {
+            "long_name": "distance from transducer",
+            "units": "m",
+            "coverage_content_type": "coordinate",
+            "comment": (
+                "Distance from the transducer to the center of each bin, "
+                "not water depth. Bin depth depends on the depth of the "
+                "instrument and whether it looks up or down, and varies in "
+                "time with mooring knockdown. The processed dataset provides "
+                "actual water depth as `depth`."
+            ),
         },
         "u": {
             "long_name": "u",

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -5,6 +5,26 @@ import numpy as np
 import velosearaptor as vr
 
 
+def test_raw_z_attrs(rootdir):
+    """`z` in the raw output is distance from the transducer, not depth.
+
+    The attributes must say so, since the name alone does not.
+    """
+    ds = vr.io.read_raw_rdi(rootdir / "data/24606000.000")
+
+    assert ds.z.attrs["units"] == "m"
+    assert ds.z.attrs["long_name"] == "distance from transducer"
+    assert "not water depth" in ds.z.attrs["comment"]
+    # No CF standard name exists for this quantity, so claiming one would be
+    # wrong. In particular it must not claim to be `depth`.
+    assert "standard_name" not in ds.z.attrs
+
+    # Guard the reason the distinction matters: this instrument sits near
+    # 1160 dbar while z spans only tens to hundreds of metres, so z cannot be
+    # read as water depth.
+    assert ds.z.max() < float(ds.pressure.median())
+
+
 class TestTimeConversion:
     def test_single_value(self):
         test_dt64 = np.datetime64("2023-06-01 12:30:22")


### PR DESCRIPTION
Closes #52, though not the way the issue proposed — see below.

## Why not rename

The issue asks to rename `z` to `depth` in the raw output "to be consistent
with the processed output". Those two quantities are not the same thing:

- Raw `z` is `dep = arange(NCells) * CellSize + Bin1Dist`, the distance from the
  transducer to the center of each bin.
- Processed `depth` is actual water depth, computed in `madcp.py` as
  `pdepth + sign * dat.dep`, i.e. the depth of the instrument plus or minus that
  range depending on orientation.

In the `24606000.000` test file the instrument sits near **1160 dbar** while `z`
spans **25 to 314 m**. Renaming would give `depth` two incompatible meanings
across the two outputs, differing by the depth of the instrument — the opposite
of the consistency the issue is after.

There is also a structural obstacle: real bin depth varies in time with mooring
knockdown, so a truthful `depth` in the raw output would have to be 2-D
(time × bin). It cannot be a 1-D coordinate the way processed `depth` is, because
the processed data has been gridded onto a fixed depth axis.

## What this does instead

Keeps the name and documents the quantity, so the distinction is discoverable
from the data rather than from the source:

```
long_name:              distance from transducer
units:                  m
coverage_content_type:  coordinate
comment:                Distance from the transducer to the center of each bin,
                        not water depth. Bin depth depends on the depth of the
                        instrument and whether it looks up or down, and varies
                        in time with mooring knockdown. The processed dataset
                        provides actual water depth as `depth`.
```

The entry lives in `io.cf_conventions()` alongside the processed-output
definitions, so there is one source of truth.

**No `standard_name` is set.** CF has no standard name for the range from an ADCP
transducer to a bin, and claiming `depth` would be wrong. The omission is
deliberate and commented.

## Tests

Adds `test_raw_z_attrs`, which checks the attributes are present, asserts that no
`standard_name` is claimed, and guards the reason the distinction matters by
asserting `z.max() < pressure.median()` on the test file.

Scoped deliberately to `z`. Bringing the rest of the raw output up to CF is #51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
