### PR TITLE
Skip the Pages deploy on forks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,6 +46,8 @@ jobs:
   # actions/deploy-pages holds the elevated permissions.
   deploy:
     needs: build
+    # Only the canonical repo has a Pages site; forks build but don't deploy.
+    if: github.repository == 'modscripps/velosearaptor'
     runs-on: ubuntu-latest
     permissions:
       pages: write


### PR DESCRIPTION
## Summary

The `docs` workflow triggers on every push to `main`, including in forks. In a fork the build job succeeds and uploads the `github-pages` artifact, then `actions/deploy-pages@v4` fails because the fork has no Pages site:

```
##[error]HttpError: Not Found
Error: Failed to create deployment (status: 404) ... Ensure GitHub Pages has been enabled
```

This gates the deploy job on the canonical repository. Forks still build the docs, so a broken pdoc build is still caught, but they no longer attempt to publish.

```yaml
  deploy:
    needs: build
    # Only the canonical repo has a Pages site; forks build but don't deploy.
    if: github.repository == 'modscripps/velosearaptor'
```

Same commit `d4ac5ad` today, for reference:

| Repo | `docs` run | Result |
|---|---|---|
| `modscripps/velosearaptor` | 31203268968 | success, 34s |
| `gunnarvoet/velosearaptor` | 31204623505 | failure at deploy |

The three older `velosearaptor pdoc` failures were the same pattern, all on the fork. Nothing was wrong with the docs themselves.

## Test plan

- [x] `docs.yml` parses as valid YAML; `deploy.if` and `deploy.needs` resolve as intended
- [x] Verified the live site is served by the Actions deployment, not a branch: latest `github-pages` deployment is `d4ac5ad` at 17:39:12Z and https://modscripps.github.io/velosearaptor/ reports `last-modified: Fri, 07 Aug 2026 17:39:21 GMT`
- [ ] On merge, confirm the `docs` run on `modscripps` still builds and deploys
- [ ] Confirm the next push to the fork's `main` shows `deploy` skipped rather than failed

## Notes on the `gh-pages` branch (no code change)

While tracing this, the stale `gh-pages` branch was deleted from both this repo (was `319d45a`) and the `gunnarvoet` fork (was `ca3909b`). Both were last written 2024-05-24 and served nothing: this site publishes via `build_type: workflow`, so Pages serves the Actions artifact, not a branch. Verified before deleting (latest `github-pages` deployment `d4ac5ad` at 17:39:12Z matched the live site's `last-modified` of 17:39:21Z) and after (site returns 200 and renders current docs).

One gotcha for anyone who checks later: `GET /repos/modscripps/velosearaptor/pages` still reports

```json
"source": { "branch": "gh-pages", "path": "/" }
```

That is retained legacy metadata and is **inert** under `build_type: workflow` — it names a branch that no longer exists while the site continues to serve normally. GitHub exposes no way to clear it; re-asserting `build_type=workflow` leaves it untouched, and the only way to change it is to point it at some other real branch, which risks flipping publishing back to `legacy` for no gain. Left as-is deliberately.

Similarly, `GET /repos/modscripps/velosearaptor/pages/builds/latest` still reports the 2024 commit `319d45a`. That is the legacy branch-build API and does not reflect workflow deployments — use the deployments API for the `github-pages` environment instead.
