### PR TITLE
Bump workflow actions off Node 20

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,12 +23,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # `.pdoc-theme-gv` is a submodule needed by the build.
           submodules: 'true'
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v9
         with:
           enable-cache: true
       - name: Install dependencies
@@ -38,7 +38,7 @@ jobs:
         # ghdocs invokes pdoc directly, so run it inside the uv-managed venv.
         run: uv run make ghdocs
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/
 
@@ -58,4 +58,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,8 @@ jobs:
           # `.pdoc-theme-gv` is a submodule needed by the build.
           submodules: 'true'
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        # Pinned to an exact release: setup-uv publishes no floating `v9` tag.
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        # Pinned to an exact release: setup-uv publishes no floating `v9` tag.
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v9
         with:
           enable-cache: true
       - name: Install dependencies


### PR DESCRIPTION
## Summary

Every workflow run currently emits:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/checkout@v4`, `actions/upload-artifact@v4`, `astral-sh/setup-uv@v6`.

This moves each pin to a release that targets Node 24 natively.

| Action | Before | After | Runs on |
|---|---|---|---|
| `actions/checkout` | v4 | **v7** | node24 |
| `astral-sh/setup-uv` | v6 | **v9.0.0** | node24 |
| `actions/upload-pages-artifact` | v3 | **v5** | composite |
| `actions/deploy-pages` | v4 | **v5** | node24 |

`actions/upload-artifact` is not referenced directly — it arrives through `upload-pages-artifact`, whose v5 pins `upload-artifact@v7.0.0`. That is what clears it from the warning.

## Breaking-change review

Each input this repo actually passes was checked against `action.yml` at the target tag:

- `checkout` → `submodules` still present (needed for the `.pdoc-theme-gv` submodule)
- `setup-uv` → `enable-cache` still present
- `upload-pages-artifact` → `path` still present
- `deploy-pages` → passes no inputs

One breaking change reaches this repo:

- **`setup-uv` v9** changes the `prune-cache` default to `false` ([astral-sh/setup-uv#967](https://github.com/astral-sh/setup-uv/pull/967)), to ease load on PyPI. Cache entries get larger. Accepted as the upstream default; add `prune-cache: true` if the repo's 10 GB Actions cache allowance ever becomes tight.

The others do not apply:

- `setup-uv` v8 removed a deprecated custom version-manifest format — not used here
- `setup-uv` v6 removed the `pyproject-file` and `uv-file` inputs — not used here
- `setup-uv` v7 changed shortcut handling for minimum version specifiers — no uv version is pinned here
- `checkout` v5 raised the minimum compatible runner version — satisfied by `ubuntu-latest`

## Why setup-uv is pinned exactly

The first push here used `astral-sh/setup-uv@v9` and failed before any step ran:

```
Unable to resolve action `astral-sh/setup-uv@v9`, unable to find version `v9`
```

setup-uv stopped publishing floating major tags after v6 — `refs/tags/v6` exists, `v7`/`v8`/`v9` do not, only exact releases like `v9.0.0`. So that one is pinned to `v9.0.0` with a comment; shortening it to `@v9` will break the workflow. The other three actions do publish floating majors (`checkout` `refs/tags/v7`, `upload-pages-artifact` `refs/tags/v5`, `deploy-pages` `refs/tags/v5`) and stay on major pins.

## Test plan

- [x] Both workflow files parse as valid YAML after the edits
- [x] No `uses:` pin left on an older major (`grep` over `.github/workflows/`)
- [x] Diff touches pins only; the fork deploy guard from #75 is unchanged
- [x] `test` passes on this PR (run 31207926295, no Node 20 annotation)
- [ ] On merge, the `docs` run still builds and deploys, with no Node 20 annotation
