### PR TITLE
Pass ibad when recalculating xyze after binmapping

### DIFF
--- a/src/velosearaptor/madcp.py
+++ b/src/velosearaptor/madcp.py
@@ -1249,7 +1249,7 @@ class ProcessADCP:
                 if binmap:
                     self._binmap_all_beams(ens)
                     # Now we have to recalculate xyze with the binmapped data.
-                    self._calculate_xyze(ens)
+                    self._calculate_xyze(ens, ibad=self.ibad)
 
                 self._edit(ens)  # modifies xyze
                 self._to_enu(ens)  # transform to earth coords (east, north, up)

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -1,0 +1,36 @@
+"""Tests for editing/QC behavior in velosearaptor.madcp.ProcessADCP."""
+
+import numpy as np
+import pytest
+
+from velosearaptor.madcp import ProcessADCP
+
+META_DATA = {
+    "mooring": "Test",
+    "project": "Test",
+    "lon": 0,
+    "lat": 0,
+}
+
+
+@pytest.fixture
+def adcpfile(rootdir):
+    return rootdir / "data/binmap_16670013.000"
+
+
+def test_binmap_honors_ibad(adcpfile):
+    """A beam excluded via ibad must stay excluded when binmapping
+    recomputes the beam-to-xyz transform (issue #79)."""
+    proc_4beam = ProcessADCP(adcpfile, META_DATA, magdec=0.0)
+    proc_4beam.process_pings(binmap=True)
+    u_4beam = proc_4beam.ds.u.values
+
+    proc_3beam = ProcessADCP(adcpfile, META_DATA, magdec=0.0, ibad=0)
+    proc_3beam.process_pings(binmap=True)
+    u_3beam = proc_3beam.ds.u.values
+
+    # A 3-beam solution must differ from the 4-beam solution. With ibad
+    # dropped in the recomputed transform, the two results are identical.
+    both_finite = np.isfinite(u_4beam) & np.isfinite(u_3beam)
+    assert both_finite.sum() > 0
+    assert not np.allclose(u_4beam[both_finite], u_3beam[both_finite])


### PR DESCRIPTION
## Summary
`process_pings(binmap=True)` recomputes the beam-to-xyz transform via `_calculate_xyze(ens)` without passing `self.ibad`, so a beam excluded at init (and honored by `Multiread` in the non-binmapped path) was silently re-included in the binmapped product. One-line fix.

Closes #79.

## Test plan
- New test `test_binmap_honors_ibad` asserts that a 3-beam (`ibad=0`) binmapped result differs from the 4-beam result. It fails on main (the two are identical) and passes with the fix.
- Full suite: 14 passed.