### PR TITLE
Scale velocity standard error by good pings per bin

### DIFF
--- a/src/velosearaptor/io.py
+++ b/src/velosearaptor/io.py
@@ -481,6 +481,16 @@ def cf_conventions():
             "standard_name": "number_of_observations",
             "coverage_content_type": "auxiliaryInformation",
         },
+        "ngood": {
+            "long_name": "number of good pings",
+            "standard_name": "number_of_observations",
+            "coverage_content_type": "qualityInformation",
+            "comment": (
+                "Number of pings per depth bin that passed editing and "
+                "entered the time average. The basis for pg and for the "
+                "velocity standard errors."
+            ),
+        },
         "pg": {
             "long_name": "percent good",
             "standard_name": "proportion_of_acceptable_signal_returns_from_acoustic_instrument_in_sea_water",

--- a/src/velosearaptor/madcp.py
+++ b/src/velosearaptor/madcp.py
@@ -1327,6 +1327,7 @@ class ProcessADCP:
         uvwe_std = np.full((nens, ndgrid, 4), np.nan, dtype=np.float32)
 
         pg = np.zeros((nens, ndgrid), dtype=np.int8)
+        ngood = np.zeros((nens, ndgrid), dtype=np.int16)
         amp = np.full((nens, ndgrid), np.nan, dtype=np.float32)
 
         temperature = np.full((nens,), np.nan, dtype=np.float32)
@@ -1357,7 +1358,8 @@ class ProcessADCP:
                 uvwe_std[i] = np.nanstd(ens.enu_grid, axis=0)
                 amp[i] = np.nanmean(ens.amp_grid, axis=0)
 
-            pgi = 100 * np.sum(~np.isnan(ens.enu_grid[..., 0]), axis=0) // nprofs
+            ngood[i] = np.sum(~np.isnan(ens.enu_grid[..., 0]), axis=0)
+            pgi = 100 * ngood[i] // nprofs
             pg[i] = pgi.astype(np.int8)
 
             p = np.ma.filled(ens.pressure, np.nan)
@@ -1378,6 +1380,7 @@ class ProcessADCP:
             w_std=uvwe_std[..., 2],
             e_std=uvwe_std[..., 3],
             pg=pg,
+            ngood=ngood,
             amp=amp,
             temperature=temperature,
             pressure=pressure,
@@ -1435,6 +1438,7 @@ class ProcessADCP:
         uvwe_std = np.ma.zeros((nens, ndgrid, 4), dtype=np.float32)
 
         pg = np.zeros((nens, ndgrid), dtype=np.int8)
+        ngood = np.zeros((nens, ndgrid), dtype=np.int16)
         amp = np.ma.zeros((nens, ndgrid), dtype=np.float32)
 
         temperature = np.ma.zeros((nens,), dtype=np.float32)
@@ -1477,7 +1481,8 @@ class ProcessADCP:
             uvwe_inst = ens.enu.mean(axis=0)
             uvwe_std_inst = ens.enu.std(axis=0)
 
-            pgi_inst = 100 * ens.enu[..., 0].count(axis=0) // nprofs
+            ngood_inst = ens.enu[..., 0].count(axis=0)
+            pgi_inst = 100 * ngood_inst // nprofs
 
             if pg_condition is not None:
                 pgi_index = pgi_inst < pg_condition
@@ -1509,6 +1514,11 @@ class ProcessADCP:
             # seems like that's what we need to do here.
             pgi_grid = interp1(depth, pgi_inst, self.dgrid, axis=0, method="linear")
             pg[i] = pgi_grid.astype(np.int8)
+            ngood_grid = np.ma.filled(
+                interp1(depth, ngood_inst, self.dgrid, axis=0, method="linear"),
+                np.nan,
+            )
+            ngood[i] = np.nan_to_num(ngood_grid).astype(np.int16)
 
             # Not changed to averaging in instrument-relative coordinates first.
             amp[i] = ens.amp_grid.mean(axis=0)
@@ -1528,6 +1538,7 @@ class ProcessADCP:
             w_std=uvwe_std[..., 2],
             e_std=uvwe_std[..., 3],
             pg=pg,
+            ngood=ngood,
             amp=amp,
             temperature=temperature,
             pressure=pressure,
@@ -1698,11 +1709,18 @@ class ProcessADCP:
             if var in out:
                 out = out.drop(var)
 
-        # Change u/v/w std to standard error by dividing by sqrt(npings)
-        for var in ["u", "v", "w"]:
-            if f"{var}_std" in out:
-                out = out.rename({f"{var}_std": f"{var}_error"})
-                out[f"{var}_error"] = out[f"{var}_error"] / np.sqrt(out["npings"])
+        # Change u/v/w std to standard error. Scale by the number of pings
+        # that actually entered the mean in each bin; fall back to the total
+        # ping count if the per-bin count is not available.
+        if any(f"{var}_std" in out for var in ["u", "v", "w"]):
+            if "ngood" in out:
+                n_samples = out["ngood"].where(out["ngood"] > 0)
+            else:
+                n_samples = out["npings"]
+            for var in ["u", "v", "w"]:
+                if f"{var}_std" in out:
+                    out = out.rename({f"{var}_std": f"{var}_error"})
+                    out[f"{var}_error"] = out[f"{var}_error"] / np.sqrt(n_samples)
 
         # Calculate transducer depth from pressure
         out["xducer_depth"] = -gsw.z_from_p(out.pressure, self.lat)

--- a/tests/test_std_error.py
+++ b/tests/test_std_error.py
@@ -1,0 +1,88 @@
+"""Tests for velocity standard-error scaling (issue #80).
+
+The standard error of a time-averaged velocity must be computed from the
+number of pings that actually entered the mean in each depth bin, not from
+the total number of pings in the averaging interval.
+"""
+
+import numpy as np
+import pytest
+from pycurrents.system import Bunch
+
+from velosearaptor.madcp import ProcessADCP
+
+META_DATA = {
+    "mooring": "Test",
+    "project": "Test",
+    "lon": 0,
+    "lat": 0,
+}
+
+
+def _bare_instance_with_ave():
+    """Build a ProcessADCP shell with a synthetic `ave` for testing _ave2nc."""
+    p = ProcessADCP.__new__(ProcessADCP)
+    p.lat = 0.0
+
+    ntime, ndep = 2, 3
+    npings = np.array([100, 50], dtype=np.int16)
+    # Good pings per (time, depth) bin; one bin has none.
+    ngood = np.array([[100, 50, 25], [50, 10, 0]], dtype=np.int16)
+    pg = (100 * ngood // npings[:, np.newaxis]).astype(np.int8)
+    u_std = np.full((ntime, ndep), 0.1, dtype=np.float32)
+
+    p.ave = Bunch(
+        u=np.ones((ntime, ndep), dtype=np.float32),
+        v=np.ones((ntime, ndep), dtype=np.float32),
+        w=np.ones((ntime, ndep), dtype=np.float32),
+        e=np.zeros((ntime, ndep), dtype=np.float32),
+        u_std=u_std.copy(),
+        v_std=u_std.copy(),
+        w_std=u_std.copy(),
+        pg=pg,
+        ngood=ngood,
+        amp=np.full((ntime, ndep), 100.0, dtype=np.float32),
+        temperature=np.full((ntime,), 10.0, dtype=np.float32),
+        pressure=np.full((ntime,), 1000.0, dtype=np.float32),
+        npings=npings,
+        dday=np.array([0.0, 1 / 24]),
+        yearbase=2020,
+        dep=np.array([100.0, 110.0, 120.0]),
+    )
+    return p, u_std, ngood
+
+
+def test_std_error_uses_good_pings():
+    """u_error must be u_std / sqrt(ngood), not u_std / sqrt(npings)."""
+    p, u_std, ngood = _bare_instance_with_ave()
+    p._ave2nc()
+
+    expected = u_std.T / np.sqrt(ngood.T)  # ds is (depth, time)
+    got = p.ds.u_error.values
+
+    valid = ngood.T > 0
+    assert np.allclose(got[valid], expected[valid])
+    # No good pings, no error estimate.
+    assert np.all(np.isnan(got[~valid]))
+
+
+def test_average_ensembles_outputs_ngood(rootdir):
+    """average_ensembles must store the per-bin good-ping count that pg is
+    derived from."""
+    adcpfile = rootdir / "data/binmap_16670013.000"
+    proc = ProcessADCP(adcpfile, META_DATA, magdec=0.0)
+    proc.average_ensembles()
+    ds = proc.ds
+
+    assert "ngood" in ds
+
+    pg = ds.pg.values
+    ngood = ds.ngood.values
+    npings = ds.npings.values[np.newaxis, :]
+
+    valid = np.isfinite(pg) & (npings > 0)
+    assert valid.sum() > 0
+    assert np.all(ngood[valid] <= np.broadcast_to(npings, pg.shape)[valid])
+    # pg is defined as floor(100 * ngood / npings).
+    expected_pg = 100 * ngood[valid] // np.broadcast_to(npings, pg.shape)[valid]
+    assert np.array_equal(pg[valid].astype(np.int64), expected_pg.astype(np.int64))

--- a/tests/test_std_error.py
+++ b/tests/test_std_error.py
@@ -6,7 +6,6 @@ the total number of pings in the averaging interval.
 """
 
 import numpy as np
-import pytest
 from pycurrents.system import Bunch
 
 from velosearaptor.madcp import ProcessADCP


### PR DESCRIPTION
## Summary
`u_error`/`v_error`/`w_error` were computed as std/sqrt(npings), with npings the total number of pings in the averaging interval including pings removed by editing. In bins with low percent good this underestimates the standard error by sqrt(pg/100) (a factor of about 2.2 at pg = 20), and the bias is largest exactly where the uncertainty matters most.

- New output variable `ngood` (depth x time): the per-bin count of pings that entered the mean, i.e. the same count `pg` is derived from. Stored in both `average_ensembles` and `burst_average_ensembles` (interpolated to the depth grid in the burst path, like `pg`), with a CF attributes entry.
- `_ave2nc` scales the standard error by sqrt(ngood), NaN where no good pings; falls back to `npings` if `ngood` is absent.

Closes #80.

## Test plan
- `test_std_error_uses_good_pings`: synthetic `ave` through `_ave2nc`, asserts u_error == u_std/sqrt(ngood) and NaN where ngood = 0. Fails on main (division by npings), passes with the fix.
- `test_average_ensembles_outputs_ngood`: full `average_ensembles` on the test file, asserts `ngood` is present, bounded by npings, and satisfies pg == floor(100*ngood/npings).
- Full suite: 15 passed.