### PR TITLE
Record applied QC parameters in the output dataset

### DIFF
--- a/src/velosearaptor/io.py
+++ b/src/velosearaptor/io.py
@@ -491,6 +491,17 @@ def cf_conventions():
                 "velocity standard errors."
             ),
         },
+        "max_e_applied": {
+            "long_name": "applied error velocity threshold",
+            "units": "m s-1",
+            "coverage_content_type": "qualityInformation",
+            "comment": (
+                "Error velocity threshold applied to this averaging "
+                "interval: the minimum of the absolute threshold max_e and "
+                "max_e_deviation times the standard deviation of error "
+                "velocity within the interval."
+            ),
+        },
         "pg": {
             "long_name": "percent good",
             "standard_name": "proportion_of_acceptable_signal_returns_from_acoustic_instrument_in_sea_water",

--- a/src/velosearaptor/madcp.py
+++ b/src/velosearaptor/madcp.py
@@ -968,7 +968,10 @@ class ProcessADCP:
         ens.xyze[cond] = np.ma.masked
         e = ens.xyze[:, :, 3]
         max_e = min(ep.max_e, e.std() * ep.max_e_deviation)
-        ens.max_e_applied = max_e
+        # Store as plain float (NaN if the threshold could not be computed,
+        # e.g. for a fully masked ensemble) so it can be propagated to the
+        # output dataset.
+        ens.max_e_applied = float(max_e) if np.isfinite(max_e) else np.nan
         cond = np.abs(e) > max_e
         ens.xyze[cond] = np.ma.masked
         if ep.maskbins is not None:
@@ -1223,6 +1226,7 @@ class ProcessADCP:
 
         temperature = self.tsdat.temperature[idx_start:idx_stop]
         pressure = self.tsdat.pressure[idx_start:idx_stop]
+        max_e_applied = np.full((npings,), np.nan, dtype=np.float32)
 
         dday = self.dday[idx_start:idx_stop]
 
@@ -1252,6 +1256,7 @@ class ProcessADCP:
                     self._calculate_xyze(ens, ibad=self.ibad)
 
                 self._edit(ens)  # modifies xyze
+                max_e_applied[idx0:idx1] = ens.max_e_applied
                 self._to_enu(ens)  # transform to earth coords (east, north, up)
 
             else:
@@ -1280,6 +1285,7 @@ class ProcessADCP:
             amp=amp,
             temperature=temperature,
             pressure=pressure,
+            max_e_applied=max_e_applied,
             # npings=npings,
             dday=dday,
             yearbase=self.yearbase,
@@ -1336,6 +1342,7 @@ class ProcessADCP:
         pressure_max = np.full((nens,), np.nan, dtype=np.float32)
 
         npings = np.zeros((nens,), dtype=np.int16)
+        max_e_applied = np.full((nens,), np.nan, dtype=np.float32)
 
         dday = self.dday_mid[start:stop]
 
@@ -1343,6 +1350,7 @@ class ProcessADCP:
             ens = self.read_ensemble(iens)
             if ens is not None:
                 self._edit(ens)  # modifies xyze
+                max_e_applied[i] = ens.max_e_applied
                 self._to_enu(ens)  # transform to earth coords (east, north, up)
                 self._regrid_enu_amp(ens)
 
@@ -1387,6 +1395,7 @@ class ProcessADCP:
             pressure_std=pressure_std,
             pressure_max=pressure_max,
             npings=npings,
+            max_e_applied=max_e_applied,
             dday=dday,
             yearbase=self.yearbase,
             dep=self.dgrid,
@@ -1447,6 +1456,7 @@ class ProcessADCP:
         pressure_max = np.ma.zeros((nens,), dtype=np.float32)
 
         npings = np.zeros((nens,), dtype=np.int16)
+        max_e_applied = np.full((nens,), np.nan, dtype=np.float32)
 
         dday = self.dday_mid[start:stop]
 
@@ -1454,6 +1464,7 @@ class ProcessADCP:
             ens = self.read_ensemble(iens)
             if ens is not None:
                 self._edit(ens)  # modifies xyze
+                max_e_applied[i] = ens.max_e_applied
                 self._to_enu(ens)  # transform to earth coords (east, north, up)
                 self._regrid_enu(ens)
                 self._regrid_amp(ens)
@@ -1545,6 +1556,7 @@ class ProcessADCP:
             pressure_std=pressure_std,
             pressure_max=pressure_max,
             npings=npings,
+            max_e_applied=max_e_applied,
             dday=dday,
             yearbase=self.yearbase,
             dep=self.dgrid,
@@ -1752,8 +1764,14 @@ class ProcessADCP:
         # Add some more info.
         self.ds.attrs["orientation"] = self.orientation
         self.ds.attrs["magdec"] = self.magdec
-        for att in ["max_e", "max_e_deviation", "min_correlation"]:
-            self.ds.attrs[att] = self.editparams[att]
+        for att in ["max_e", "max_e_deviation", "min_correlation", "pg_limit"]:
+            value = self.editparams[att]
+            # netcdf attributes cannot hold None.
+            self.ds.attrs[att] = "none" if value is None else value
+        maskbins = self.editparams["maskbins"]
+        self.ds.attrs["maskbins"] = (
+            "none" if maskbins is None else np.flatnonzero(maskbins)
+        )
 
         # Add meta data if provided.
         if self.meta_data is not None:

--- a/tests/test_qc_record.py
+++ b/tests/test_qc_record.py
@@ -1,0 +1,45 @@
+"""Tests for recording applied QC parameters in the output (issue #83)."""
+
+import numpy as np
+import pytest
+
+from velosearaptor.madcp import ProcessADCP
+
+META_DATA = {
+    "mooring": "Test",
+    "project": "Test",
+    "lon": 0,
+    "lat": 0,
+}
+
+
+@pytest.fixture
+def proc(rootdir):
+    adcpfile = rootdir / "data/binmap_16670013.000"
+    return ProcessADCP(adcpfile, META_DATA, magdec=0.0)
+
+
+def test_max_e_applied_recorded(proc):
+    """The error-velocity threshold actually applied per averaging interval
+    must be stored in the output dataset."""
+    proc.average_ensembles()
+    ds = proc.ds
+
+    assert "max_e_applied" in ds
+    assert ds.max_e_applied.dims == ("time",)
+    vals = ds.max_e_applied.values
+    assert np.isfinite(vals).any()
+    # The applied threshold is min(max_e, sigma-based), so never above max_e.
+    assert np.nanmax(vals) <= proc.editparams.max_e + 1e-9
+
+
+def test_editparams_fully_recorded(proc):
+    """pg_limit and maskbins must appear in the output attributes alongside
+    the other editing parameters."""
+    maskbins = np.zeros(proc.meta_data.NCells, dtype=bool)
+    maskbins[3] = True
+    proc.parse_editparams({"maskbins": maskbins, "pg_limit": 30})
+    proc.average_ensembles()
+
+    assert proc.ds.attrs["pg_limit"] == 30
+    assert list(proc.ds.attrs["maskbins"]) == [3]


### PR DESCRIPTION
## Summary
The effective error-velocity threshold `min(max_e, std(e) * max_e_deviation)` is computed per averaging interval and was discarded after use; the output attributes recorded only `max_e` and `max_e_deviation`, from which the applied threshold cannot be reconstructed. `pg_limit` and `maskbins` were not recorded at all, so a burst-averaged file has velocities thresholded at `pg < 50` by default with no trace in the file.

- New output variable `max_e_applied` (time): the threshold applied to each averaging interval, stored by all three processing paths, with a CF attributes entry. NaN when it could not be computed (fully masked interval).
- `_add_meta_data_to_ds` now writes `pg_limit` and `maskbins` (as masked bin indices, `"none"` when unset) alongside the other editing parameters.

This is the recording half of #83; the design question about the adaptive sigma criterion itself stays in the issue for discussion.

## Test plan
- `test_max_e_applied_recorded`: after `average_ensembles`, `max_e_applied` exists on the time axis, is finite somewhere, and never exceeds `max_e`. Fails on main (variable absent).
- `test_editparams_fully_recorded`: with `pg_limit=30` and a `maskbins` masking bin 3, both appear in `ds.attrs`. Fails on main (KeyError).
- Full suite: 15 passed.