### PR TITLE
Drop depth levels that carry no velocity

### DIFF
--- a/src/velosearaptor/madcp.py
+++ b/src/velosearaptor/madcp.py
@@ -1712,8 +1712,13 @@ class ProcessADCP:
         # don't have any amplitude data (i.e. no data).
         out["pg"] = out.pg.where(~np.isnan(out.amp), other=np.nan)
 
-        # Drop depth levels with all nan
-        out = out.dropna(how="all", dim="depth")
+        # Drop depth levels that carry no velocity. Keying the drop on the
+        # whole Dataset would keep levels alive on the strength of amp alone:
+        # editing masks velocities only, so amp can be finite in levels with
+        # zero finite velocity samples, and such levels should not define the
+        # product's depth axis.
+        has_velocity = np.isfinite(out.u).any(dim="time")
+        out = out.isel(depth=has_velocity.values)
 
         # Drop pressure_std, pressure_max, and e_std
         dropvars = ["pressure_std", "pressure_max", "e_std"]

--- a/tests/test_binmap.py
+++ b/tests/test_binmap.py
@@ -1,6 +1,7 @@
 """A few examples"""
 
 import numpy as np
+import xarray as xr
 from pycurrents.system import Bunch
 
 from velosearaptor.madcp import ProcessADCP
@@ -125,6 +126,9 @@ def test_binmap(rootdir):
     ds_binmap = ADCP.ds.copy()
     ADCP.process_pings(binmap=False)
     ds_no_binmap = ADCP.ds.copy()
+    # Binmapping NaNs out-of-range cells, so the binmapped run can carry
+    # fewer velocity-bearing depth levels. Compare on the common levels.
+    ds_binmap, ds_no_binmap = xr.align(ds_binmap, ds_no_binmap, join="inner")
     uclose = np.isclose(ds_binmap.u, ds_no_binmap.u)
     assert np.sum(uclose) / uclose.size < close_frac
     vclose = np.isclose(ds_binmap.v, ds_no_binmap.v)

--- a/tests/test_dropna.py
+++ b/tests/test_dropna.py
@@ -1,0 +1,46 @@
+"""Tests for empty-level dropping in _ave2nc (issue #84).
+
+A depth level where amplitude is finite but every velocity is NaN must not
+survive into the output dataset: amp is not edited, so it can be finite in
+levels that carry no velocity data at all.
+"""
+
+import numpy as np
+from pycurrents.system import Bunch
+
+from velosearaptor.madcp import ProcessADCP
+
+
+def _bare_instance_with_ave():
+    """ProcessADCP shell with a synthetic `ave`: three depth levels, of
+    which one is fully valid, one has amp only, one is fully empty."""
+    p = ProcessADCP.__new__(ProcessADCP)
+    p.lat = 0.0
+
+    ntime, ndep = 2, 3
+    u = np.full((ntime, ndep), 0.5, dtype=np.float32)
+    amp = np.full((ntime, ndep), 100.0, dtype=np.float32)
+    u[:, 1] = np.nan  # level 1: velocity gone, amp still finite
+    u[:, 2] = np.nan  # level 2: nothing at all
+    amp[:, 2] = np.nan
+
+    p.ave = Bunch(
+        u=u.copy(),
+        v=u.copy(),
+        w=u.copy(),
+        e=u.copy(),
+        pg=np.full((ntime, ndep), 100, dtype=np.int8),
+        amp=amp,
+        temperature=np.full((ntime,), 10.0, dtype=np.float32),
+        pressure=np.full((ntime,), 1000.0, dtype=np.float32),
+        dday=np.array([0.0, 1 / 24]),
+        yearbase=2020,
+        dep=np.array([100.0, 110.0, 120.0]),
+    )
+    return p
+
+
+def test_amp_only_level_is_dropped():
+    p = _bare_instance_with_ave()
+    p._ave2nc()
+    assert list(p.ds.depth.values) == [100.0]


### PR DESCRIPTION
## Summary
`_ave2nc` dropped empty depth levels with `dropna(how="all", dim="depth")` on the whole Dataset. Editing masks velocities only, so `amp` can be finite in levels that carry zero finite velocity samples, and such levels survived into the product: files can advertise depth levels with no velocity at all, which breaks downstream code that selects levels by the advertised range. The drop is now keyed on velocity coverage (`u` finite anywhere in time).

Closes #84.

## Test plan
- New test `test_amp_only_level_is_dropped`: a synthetic `ave` with one valid level, one amp-only level, and one empty level must come out with only the valid level. Fails on main (amp-only level survives).
- `test_binmap` now aligns the binmapped and non-binmapped datasets on common depth levels before comparing, since the binmapped run legitimately carries fewer velocity-bearing levels under the new rule.
- Full suite: 14 passed.