### PR TITLE
Compute percent good in process_pings

### DIFF
--- a/src/velosearaptor/madcp.py
+++ b/src/velosearaptor/madcp.py
@@ -1263,8 +1263,12 @@ class ProcessADCP:
 
             uvwe[idx0:idx1] = ens.enu
 
-            # pgi = 100 * ens.enu_grid[..., 0].count(axis=0) // nprofs
-            # pg[i] = pgi.astype(np.int8)
+            # Percent good is binary for single-ping data: 100 where the ping
+            # survived editing, 0 where it was edited out. Binmapped data can
+            # carry unmasked NaN, so test for that as well as for the mask.
+            u = ens.enu[..., 0]
+            good = np.isfinite(np.ma.filled(u, np.nan)) & ~np.ma.getmaskarray(u)
+            pg[idx0:idx1] = 100 * good.astype(np.int8)
             amp[idx0:idx1] = ens.amp.mean(axis=-1)  # Average over beams... why?
 
         self.ave = Bunch(

--- a/tests/test_process_pings_pg.py
+++ b/tests/test_process_pings_pg.py
@@ -1,0 +1,34 @@
+"""Test percent good in single-ping processing (issue #77).
+
+For single-ping data, percent good is binary: 100 where the ping survived
+editing, 0 where it was edited out. It must not be zero everywhere.
+"""
+
+import numpy as np
+
+from velosearaptor.madcp import ProcessADCP
+
+META_DATA = {
+    "mooring": "Test",
+    "project": "Test",
+    "lon": 0,
+    "lat": 0,
+}
+
+
+def test_process_pings_pg(rootdir):
+    adcpfile = rootdir / "data/binmap_16670013.000"
+    proc = ProcessADCP(adcpfile, META_DATA, magdec=0.0)
+    proc.process_pings()
+    ds = proc.ds
+
+    good = np.isfinite(ds.u.values)
+    pg = ds.pg.values
+
+    assert good.sum() > 0
+    assert np.all(pg[good] == 100)
+
+    # Where amplitude is present but the velocity was edited out, pg is 0.
+    edited = np.isfinite(ds.amp.values) & ~good
+    assert edited.sum() > 0
+    assert np.all(pg[edited] == 0)


### PR DESCRIPTION
## Summary
In `process_pings` the `pg` variable was allocated as zeros and the computation was commented out, so the single-ping product carried `pg = 0` wherever there was data (`_ave2nc` NaNs it only where `amp` is NaN). Any downstream percent-good filter, at any threshold above zero, removed the entire single-ping dataset.

For single-ping data percent good is binary: 100 where the ping survived editing, 0 where it was edited out. The implementation tests both the mask and unmasked NaN, since binmapped data carries the latter.

Closes #77.

## Test plan
- New test `test_process_pings_pg`: after `process_pings` on the test file, pg == 100 wherever u is finite and pg == 0 where amp is present but the velocity was edited out. Fails on main (pg == 0 everywhere).
- Full suite: 14 passed.